### PR TITLE
Make 'apply_basis' case-insensitive

### DIFF
--- a/include/nwchemex/apply_basis.hpp
+++ b/include/nwchemex/apply_basis.hpp
@@ -1,5 +1,6 @@
 #include <chemcache/chemcache.hpp>
 #include <chemist/chemist.hpp>
+#include <utilities/strings/string_tools.hpp> // for tolower_string()
 
 namespace nwchemex {
 
@@ -19,8 +20,10 @@ inline auto apply_basis(
   const chemist::BasisSetManager& man = chemcache::nwx_basis_set_manager()) {
     chemist::AOBasisSet<double> aos;
 
+    std::string lowercase_name = utilities::strings::tolower_string(name);
+
     for(const auto& ai : mol) {
-        auto ci = man.get_basis(name, ai.Z());
+        auto ci = man.get_basis(lowercase_name, ai.Z());
         for(auto i : {0, 1, 2}) ci.coord(i) = ai.coords()[i];
         aos.add_center(ci);
     }

--- a/tests/apply_basis.cpp
+++ b/tests/apply_basis.cpp
@@ -33,4 +33,11 @@ TEST_CASE("Convenience Functions") {
         REQUIRE(nwchemex::apply_basis("sto-3g", water).basis_set() ==
                 corr_bs(water));
     }
+    SECTION("apply_basis_case_insensitive") {
+        std::cout.precision(std::numeric_limits<double>::max_digits10);
+        MoleculeManager mm = chemcache::nwx_molecule_manager();
+        Molecule water     = mm.at("water");
+        REQUIRE(nwchemex::apply_basis("STo-3G", water).basis_set() ==
+                corr_bs(water));
+    }
 }


### PR DESCRIPTION
<!--- All PRs will be manually reviewed prior to acceptance. They also must
      pass CI testing. --->

## Status

<!--- Please check this box when your PR is ready to be reviewed --->
- [x] Ready to go

## Brief Description

Fixes NWChemEx-Project/Chemist#127, where `apply_basis` originated. This lowercases any name provided to the `nwx::apply_basis` function, which should effectively make basis set names case-insensitive. The basis set names generated in ChemCache should already be lowercased, but I am going to check there next to see if anything needs fixing.
