### PR TITLE
Use ninja and ccache in CI build workflow

### DIFF
--- a/.github/workflows/c-cpp.yaml
+++ b/.github/workflows/c-cpp.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - master
-
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,8 +24,13 @@ jobs:
           cmake_version: ${{ matrix.cmake_version }}
           gcc_version: ${{ matrix.gcc_version }}
         run: >
-          .github/workflows/scripts/get_dependencies.sh gcc gcovr cmake
+          .github/workflows/scripts/get_dependencies.sh gcc gcovr cmake ninja
           openblas cblas lapacke scalapack boost eigen3 openmpi cppyy numpy
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.1
+        with:
+          max-size: "1500M"
+          key: ${{ matrix.cmake_version }}-${{ matrix.gcc_version }}
       - name: cache-libint
         id: cache
         uses: actions/cache@v2
@@ -44,10 +49,10 @@ jobs:
           cd libint-2.6.0
           export CXX=`which g++`
           export CC=`which gcc`
-          ../cmake-3.16.3-Linux-x86_64/bin/cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_FLAGS="-std=c++17" -DBUILD_SHARED_LIBS=ON -DCPP_GITHUB_TOKEN=$CPP_GITHUB_TOKEN
+          ../cmake-3.16.3-Linux-x86_64/bin/cmake -H. -GNinja -Bbuild -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_FLAGS="-std=c++17" -DBUILD_SHARED_LIBS=ON -DCPP_GITHUB_TOKEN=$CPP_GITHUB_TOKEN
           cd build
-          make
-          make install
+          ninja
+          ninja install
       - name: Build and test
         env:
           cmake_version: ${{ matrix.cmake_version }}


### PR DESCRIPTION
<!--- All PRs will be manually reviewed prior to acceptance. They also must
      pass CI testing. --->

## Status

<!--- Please check this box when your PR is ready to be reviewed --->
- [x] Ready to go


## Brief Description
This PR aims to reduce CI build time by using `ninja` and `ccache`.
 
<!--- One or two sentences to quickly describe what your PR does --->

## Detailed Description (optional)
- `ninja` becomes a dependency of the CI workflow.
- Switches to `ninja` instead of `make`.
- Use `ccache` Github [action](https://github.com/hendrikmuhs/ccache-action).
- Enable manual triggering of the workflow.
- Related to the [issue](https://github.com/NWChemEx-Project/.github/issues/24) in DeveloperTools.
## TODOs and/or Questions (optional)

<!--- If you are opening your PR early, so as to tell us what you are working
      on, it can be useful to have a checklist of what you plan to do and
      what you are unsure of.  That goes here --->
      
