### PR TITLE
Revert "Use ninja and ccache in CI build workflow"

### DIFF
--- a/.github/workflows/c-cpp.yaml
+++ b/.github/workflows/c-cpp.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,13 +24,8 @@ jobs:
           cmake_version: ${{ matrix.cmake_version }}
           gcc_version: ${{ matrix.gcc_version }}
         run: >
-          .github/workflows/scripts/get_dependencies.sh gcc gcovr cmake ninja
+          .github/workflows/scripts/get_dependencies.sh gcc gcovr cmake
           openblas cblas lapacke scalapack boost eigen3 openmpi cppyy numpy
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.1
-        with:
-          max-size: "1500M"
-          key: ${{ matrix.cmake_version }}-${{ matrix.gcc_version }}
       - name: cache-libint
         id: cache
         uses: actions/cache@v2
@@ -49,10 +44,10 @@ jobs:
           cd libint-2.6.0
           export CXX=`which g++`
           export CC=`which gcc`
-          ../cmake-3.16.3-Linux-x86_64/bin/cmake -H. -GNinja -Bbuild -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_FLAGS="-std=c++17" -DBUILD_SHARED_LIBS=ON -DCPP_GITHUB_TOKEN=$CPP_GITHUB_TOKEN
+          ../cmake-3.16.3-Linux-x86_64/bin/cmake -H. -Bbuild -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_FLAGS="-std=c++17" -DBUILD_SHARED_LIBS=ON -DCPP_GITHUB_TOKEN=$CPP_GITHUB_TOKEN
           cd build
-          ninja
-          ninja install
+          make
+          make install
       - name: Build and test
         env:
           cmake_version: ${{ matrix.cmake_version }}


### PR DESCRIPTION
Reverts NWChemEx-Project/NWChemEx#71

CI's not working with Ninja, in an attempt to restore it to a working state I'm reverting the Ninja changes. The Ninja changes are welcome to be added to CI once they've been worked out.