### PR TITLE
Disable mokup testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ if("${BUILD_TESTING}")
             PRIVATE
             BUILD_TARGET mokup
             FIND_TARGET nwx::mokup
+            CMAKE_ARGS BUILD_TESTING=OFF
     )
     cpp_add_tests(
        test_nwchemex


### PR DESCRIPTION
The aim is to stop compiling Mokup tests during NWChemEx builds.