### PR TITLE
Updates for python bindings

### DIFF
--- a/cmake/FindCppyy.cmake
+++ b/cmake/FindCppyy.cmake
@@ -27,53 +27,60 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 # Check if cppyy Python package exists
 #
 execute_process(
-    COMMAND Python3::Interpreter -c "import cppyy"
-    RESULT_VARIABLE _fcppyy_result
+    COMMAND ${Python3_EXECUTABLE} -c "import cppyy"
+    OUTPUT_VARIABLE _fcppyy_result
 )
 #
 # If cppyy exists, check version
 #
 if("${_fcppyy_result}" STREQUAL "")
+    set(Cppyy_FOUND TRUE)
     execute_process(
-        COMMAND Python3::Interpreter -c "import cppyy; print(cppyy.__version__)"
-        RESULT_VARIABLE _fcppyy_result2
+        COMMAND ${Python3_EXECUTABLE} -c "import cppyy; print(cppyy.__version__),"
+        OUTPUT_VARIABLE _fcppyy_result2
     )
+else()
+    set(Cppyy_FOUND FALSE)
 endif()
 #
 # Try to install cppyy Python package, if it doesn't exist or is incorrect version
 #
-if(NOT "${_fcppyy_result}" STREQUAL "" OR NOT "${_fcppyy_result2}" STREQUAL "${cppyy_version}")
+if("${_fcppyy_result}" STREQUAL "" OR NOT "${_fcppyy_result2}" VERSION_EQUAL "${cppyy_version}")
     if(DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
-      set(_pip_args)
+        set(_pip_args)
     else()
-      set(_pip_args "--user")
+        set(_pip_args "--user")
     endif()
     set(_pypkg_name "cppyy==${cppyy_version}")
     execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install ${_pypkg_name} ${_pip_args})
     #
     # Check again if cppyy Python works
     #
-    execute_process(COMMAND Python3::Interpreter -c "import cppyy" RESULT_VARIABLE _fcppyy_result)
-    if(NOT "${_fcppyy_result}" STREQUAL "")
-       set(Cppyy_FOUND FALSE)
-    else()
+    execute_process(COMMAND ${Python3_EXECUTABLE} -c "import cppyy" OUTPUT_VARIABLE _fcppyy_result)
+    if("${_fcppyy_result}" STREQUAL "")
+        set(Cppyy_FOUND TRUE)
     	execute_process(
-        	COMMAND Python3::Interpreter -c "import cppyy; print(cppyy.__version__)"
-        	RESULT_VARIABLE _fcppyy_result2
+            COMMAND ${Python3_EXECUTABLE} -c "import cppyy; print(cppyy.__version__),"
+        	OUTPUT_VARIABLE _fcppyy_result2
     	)
+    else()
+        set(Cppyy_FOUND FALSE)
     endif()
     #
     # Check the version again
     #
-    if("${_fcppyy_result2}" STREQUAL "${cppyy_version}")
-       set(Cppyy_FOUND TRUE)
+    if("${_fcppyy_result2}" VERSION_EQUAL "${cppyy_version}")
+        set(Cppyy_FOUND TRUE)
     else()
-       set(Cppyy_FOUND FALSE)
+        set(Cppyy_FOUND FALSE)
     endif()
 else()
     set(Cppyy_FOUND TRUE)
 endif()
 
 if(NOT Cppyy_FOUND)
-    message(WARNING "CMake could not install cppyy, try installing cppyy ${cppyy_version} manually.")
+    message("Python3: ${Python3_EXECUTABLE}")
+    message("import output: ${_fcppyy_result}")
+    message("version output: ${_fcppyy_result2}")
+    message(FATAL_ERROR "CMake could not install cppyy, try installing cppyy ${cppyy_version} manually.")
 endif()

--- a/cmake/nwx_python_mods.cmake
+++ b/cmake/nwx_python_mods.cmake
@@ -47,9 +47,6 @@ function(cppyy_make_python_package)
     #-----------------------Make sure we have cppyy installed-------------------
     #---------------------------------------------------------------------------
     find_package(Cppyy REQUIRED)
-    if(NOT Cppyy_FOUND)
-        message(FATAL_ERROR "Requested python bindings, but cppyy not found!")
-    endif()
     #---------------------------------------------------------------------------
     #--------------------------Argument Parsing---------------------------------
     #---------------------------------------------------------------------------


### PR DESCRIPTION
* Fix a possible break of python bindings when BTAS_USE_BLAS_LAPACK is true
* Disable including implicit directories, which creates problems with IntelLLVM
* Update cppyy to 2.4.1
* Attempt to fix this [issue](https://github.com/NWChemEx-Project/.github/issues/26) about stopping build when cppyy is not correctly installed.

Question:
If approved should I move these changes to .github repo or replicate them in other repos? Currently, .github cmake files are not synced to other repos.