### PR TITLE
Default Tensor Shape for XC

### DIFF
--- a/src/nwchemex/load_modules.cpp
+++ b/src/nwchemex/load_modules.cpp
@@ -42,6 +42,7 @@ void set_scf_default_modules(pluginplay::ModuleManager& mm) {
     mm.change_submod("SCF Step", "Overlap", "Overlap");
     mm.change_submod("DIIS Fock Matrix", "Overlap", "Overlap");
     mm.change_submod("SCFDIIS Step", "Overlap", "Overlap");
+    mm.change_submod("XC", "Tensor Shape", "OneTileShape");
 }
 
 // Uncomment once MP2 is working again


### PR DESCRIPTION
**PR Type**

- [ ] Breaking change
- [ ] Feature
- [x] Patch

**Brief Description**
Sets the default "Tensor Shape" submodule for the "XC" module.

**Not In Scope**


**PR Checklist**

- [x] [Is documented](https://nwchemex-project.github.io/.github/documenting/index.html)
- [x] [Is tested](https://nwchemex-project.github.io/.github/testing/index.html)
- [x] [Adheres to applicable organization standards](https://nwchemex-project.github.io/.github/conventions/index.html)
