### PR TITLE
integrals plugin added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,11 @@ cmaize_find_or_build_dependency(
                BUILD_PYBIND11_PYBINDINGS=ON
 )
 
+include(get_integrals)
+
 #TOOD: Replace with cmaize_add_library when it supports Python
 add_library(${PROJECT_NAME} INTERFACE)
-target_link_libraries(${PROJECT_NAME} INTERFACE chemcache friendzone)
+target_link_libraries(${PROJECT_NAME} INTERFACE chemcache friendzone integrals)
 
 if("${BUILD_TESTING}")
     include(CTest)
@@ -82,7 +84,8 @@ if("${BUILD_TESTING}")
 
     nwx_pybind11_tests(
         py_${PROJECT_NAME} ${PYTHON_TEST_DIR}/unit_tests/test_nwchemex.py
-        SUBMODULES parallelzone pluginplay chemist simde chemcache friendzone
+        SUBMODULES parallelzone pluginplay chemist simde chemcache friendzone 
+                   integrals
     )
 
     # Workaround for the FriendZone being pure python (and thus not in the build


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Integrals plugin is now available in integration tests that depend on NWChemEx. 

**TODOs**
R2g.
