### PR TITLE
"Proper" Build When `BUILD_PYBIND11_PYBINDINGS=OFF`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ cmaize_find_or_build_optional_dependency(
     BUILD_TARGET friendzone
     FIND_TARGET nwx::friendzone
     CMAKE_ARGS BUILD_TESTING=OFF
-               BUILD_PYBIND11_PYBINDINGS="${BUILD_PYBIND11_PYBINDINGS}"
+               BUILD_PYBIND11_PYBINDINGS=${BUILD_PYBIND11_PYBINDINGS}
 )
 
 if(NOT TARGET scf) # Circular dependency band-aid
@@ -70,7 +70,7 @@ cmaize_find_or_build_dependency(
     BUILD_TARGET scf
     FIND_TARGET nwx::scf
     CMAKE_ARGS BUILD_TESTING=OFF
-               BUILD_PYBIND11_PYBINDINGS="${BUILD_PYBIND11_PYBINDINGS}"
+               BUILD_PYBIND11_PYBINDINGS=${BUILD_PYBIND11_PYBINDINGS}
 )
 endif()
 
@@ -82,7 +82,7 @@ cmaize_find_or_build_dependency(
     BUILD_TARGET nux
     FIND_TARGET nwx::nux
     CMAKE_ARGS BUILD_TESTING=OFF
-               BUILD_PYBIND11_PYBINDINGS="${BUILD_PYBIND11_PYBINDINGS}"
+               BUILD_PYBIND11_PYBINDINGS=${BUILD_PYBIND11_PYBINDINGS}
 )
 endif()
 include(get_chemcache)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,14 +51,15 @@ if("${BUILD_FULL_CHEMCACHE}")
     set(NWX_CHEMCACHE_VERSION generated_data)
 endif()
 
-cmaize_find_or_build_dependency(
+cmaize_find_or_build_optional_dependency(
     friendzone
+    BUILD_PYBIND11_PYBINDINGS
     URL github.com/NWChemEx/FriendZone
     VERSION ${NWX_FRIENDZONE_VERSION}
     BUILD_TARGET friendzone
     FIND_TARGET nwx::friendzone
     CMAKE_ARGS BUILD_TESTING=OFF
-               BUILD_PYBIND11_PYBINDINGS=ON
+               BUILD_PYBIND11_PYBINDINGS="${BUILD_PYBIND11_PYBINDINGS}"
 )
 
 if(NOT TARGET scf) # Circular dependency band-aid
@@ -69,7 +70,7 @@ cmaize_find_or_build_dependency(
     BUILD_TARGET scf
     FIND_TARGET nwx::scf
     CMAKE_ARGS BUILD_TESTING=OFF
-               BUILD_PYBIND11_PYBINDINGS=ON
+               BUILD_PYBIND11_PYBINDINGS="${BUILD_PYBIND11_PYBINDINGS}"
 )
 endif()
 
@@ -81,7 +82,7 @@ cmaize_find_or_build_dependency(
     BUILD_TARGET nux
     FIND_TARGET nwx::nux
     CMAKE_ARGS BUILD_TESTING=OFF
-               BUILD_PYBIND11_PYBINDINGS=ON
+               BUILD_PYBIND11_PYBINDINGS="${BUILD_PYBIND11_PYBINDINGS}"
 )
 endif()
 include(get_chemcache)
@@ -93,7 +94,7 @@ target_link_libraries(
     ${PROJECT_NAME} INTERFACE chemcache friendzone integrals scf nux
 )
 
-if("${BUILD_TESTING}")
+if("${BUILD_TESTING}" AND "${BUILD_PYBIND11_PYBINDINGS}")
     include(CTest)
     include(nwx_pybind11)
     set(PYTHON_TEST_DIR "${NWCHEMEX_TESTS_DIR}/python")


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
This library has the option to turn off Python bindings, which seems a bit odd given that it is technically Python only. This option is useful though for integration testing of other repos that can meaningfully turn off Python bindings (e.g. SCF), by aggregating all of the C++ libraries that make up the NWChemEx stack. In the current build, setting `BUILD_PYBIND11_PYBINDINGS=OFF` was minimally confusing, since all of the dependencies were hardcoded to build the Python bindings and the tests require Python. These changes alter the build so that the dependencies built when `BUILD_PYBIND11_PYBINDINGS=OFF` are those for whom that setting is truly applicable (i.e. those that can be built as C++ only).